### PR TITLE
fix: reset binstubs

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run


### PR DESCRIPTION
fix: reset binstubs

```
rake app:update:bin
```

The `rails generate controller` method was hanging, so I found this solution in [a Stack Overflow thread](https://stackoverflow.com/questions/31857365/rails-generate-commands-hang-when-trying-to-create-a-model).